### PR TITLE
Potential fix for code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/components/searchComponents/js/insertSearchVideoList.js
+++ b/components/searchComponents/js/insertSearchVideoList.js
@@ -24,15 +24,30 @@ function edit_menu() {
     return menu;
 }
 
+// Utility function to escape HTML special characters
+function escapeHTML(str) {
+    return str.replace(/[&<>"']/g, function(match) {
+        const escapeMap = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        };
+        return escapeMap[match];
+    });
+}
+
 // 검색 결과가 없을 때 출력 내용 생성
 function no_result_html(query) {
+    const sanitizedQuery = escapeHTML(query);
     const html_template = 
     `
     <div class="no-search-result-img-box">
         <img src="../../images/search-no-result.svg" alt="no-search-result">
     </div>
     <div>
-        <span class="no-result-message">${query} 검색결과가 없습니다.</span>
+        <span class="no-result-message">${sanitizedQuery} 검색결과가 없습니다.</span>
     </div>
     <div>
         <span class="no-result-recommend">다른 검색어를 시도해 보거나 검색 필터를 삭제하세요.</span>


### PR DESCRIPTION
Potential fix for [https://github.com/ase10git/CloneTube/security/code-scanning/2](https://github.com/ase10git/CloneTube/security/code-scanning/2)

To fix the issue, we need to sanitize or escape the `query` parameter before using it in the HTML template. The best approach is to use a library or utility function to perform contextual escaping for HTML content. This ensures that any special characters in the `query` string are properly encoded, preventing the execution of malicious scripts.

1. Introduce a utility function, `escapeHTML`, to escape special characters in the `query` string.
2. Use this function to sanitize the `query` parameter before interpolating it into the HTML template in `no_result_html(query)`.
3. Ensure that the `escapeHTML` function is defined in the same file or imported from a utility module.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
